### PR TITLE
multinode: retry selection during initial dial; chains/txmgr: non-blocking start

### DIFF
--- a/multinode/node_fsm.go
+++ b/multinode/node_fsm.go
@@ -42,6 +42,11 @@ var (
 // Node is a FSM (finite state machine)
 type nodeState int
 
+// isInitializing returns true if the node is still doing the initial dial & verification.
+func (n nodeState) isInitializing() bool {
+	return n == nodeStateUndialed || n == nodeStateDialed
+}
+
 func (n nodeState) String() string {
 	switch n {
 	case nodeStateUndialed:


### PR DESCRIPTION
Following #18, we have smoke test failures from critical logs which occur only during startup, even though the tests themselves pass just fine afterwards. This PR changes `MultiNode.selectNode` to wait and retry if any nodes are still undialed.

Supports: 
- https://github.com/smartcontractkit/chainlink/pull/15995
- https://github.com/smartcontractkit/chainlink-solana/pull/1043