### PR TITLE
Provide a correct path to the linter file .golangci.yml

### DIFF
--- a/.github/workflows/golangci_lint.yml
+++ b/.github/workflows/golangci_lint.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Run golangci-lint for ${{ matrix.module }}
         uses: golangci/golangci-lint-action@v3
         with:
+          args: --config=${{ github.workspace }}/.golangci.yml
           only-new-issues: true
           version: v1.62.2
           working-directory: ${{ matrix.module }}


### PR DESCRIPTION
Without this PR no file is used at all.