### PR TITLE
Add config VerifyChainID

### DIFF
--- a/multinode/config/config.go
+++ b/multinode/config/config.go
@@ -26,6 +26,7 @@ type MultiNode struct {
 	FinalizedBlockPollInterval *config.Duration
 	EnforceRepeatableRead      *bool
 	DeathDeclarationDelay      *config.Duration
+	VerifyChainID              *bool
 
 	// Chain Configs
 	NodeNoNewHeadsThreshold      *config.Duration
@@ -73,6 +74,10 @@ func (c *MultiNodeConfig) EnforceRepeatableRead() bool { return *c.MultiNode.Enf
 
 func (c *MultiNodeConfig) DeathDeclarationDelay() time.Duration {
 	return c.MultiNode.DeathDeclarationDelay.Duration()
+}
+
+func (c *MultiNodeConfig) VerifyChainID() bool {
+	return *c.MultiNode.VerifyChainID
 }
 
 func (c *MultiNodeConfig) NodeNoNewHeadsThreshold() time.Duration {
@@ -124,6 +129,9 @@ func (c *MultiNodeConfig) SetFrom(f *MultiNodeConfig) {
 	}
 	if f.MultiNode.DeathDeclarationDelay != nil {
 		c.MultiNode.DeathDeclarationDelay = f.MultiNode.DeathDeclarationDelay
+	}
+	if f.MultiNode.VerifyChainID != nil {
+		c.MultiNode.VerifyChainID = f.MultiNode.VerifyChainID
 	}
 
 	// Chain Configs

--- a/multinode/node.go
+++ b/multinode/node.go
@@ -44,6 +44,7 @@ type NodeConfig interface {
 	EnforceRepeatableRead() bool
 	DeathDeclarationDelay() time.Duration
 	NewHeadsPollInterval() time.Duration
+	VerifyChainID() bool
 }
 
 type ChainConfig interface {
@@ -306,9 +307,11 @@ func (n *node[CHAIN_ID, HEAD, RPC]) createVerifiedConn(ctx context.Context, lggr
 // verifyConn - verifies that current connection is valid: chainID matches, and it's not syncing.
 // Returns desired state if one of the verifications fails. Otherwise, returns nodeStateAlive.
 func (n *node[CHAIN_ID, HEAD, RPC]) verifyConn(ctx context.Context, lggr logger.Logger) nodeState {
-	state := n.verifyChainID(ctx, lggr)
-	if state != nodeStateAlive {
-		return state
+	if n.nodePoolCfg.VerifyChainID() {
+		state := n.verifyChainID(ctx, lggr)
+		if state != nodeStateAlive {
+			return state
+		}
 	}
 
 	if n.nodePoolCfg.NodeIsSyncingEnabled() {

--- a/multinode/node_test.go
+++ b/multinode/node_test.go
@@ -58,6 +58,10 @@ func (n testNodeConfig) DeathDeclarationDelay() time.Duration {
 	return n.deathDeclarationDelay
 }
 
+func (n testNodeConfig) VerifyChainID() bool {
+	return true
+}
+
 type testNode struct {
 	*node[ID, Head, RPCClient[ID, Head]]
 }


### PR DESCRIPTION
### Description
Ticket: https://smartcontract-it.atlassian.net/browse/BCFR-1200

Added config `VerifyChainID` config. Solana e2e tests are using a pre-configured ChainID, but the RPC client returns a randomly generated Genesis Hash for ChainID which will not match causing e2e tests to fail.