### PR TITLE
Add PersistenceBatchSize

### DIFF
--- a/chains/heads/tracker.go
+++ b/chains/heads/tracker.go
@@ -61,6 +61,7 @@ type TrackerConfig interface {
 	FinalityTagBypass() bool
 	MaxAllowedFinalityDepth() uint32
 	PersistenceEnabled() bool
+	PersistenceBatchSize() int64
 }
 
 type headPair[HTH any] struct {


### PR DESCRIPTION
Used for trimming old evm heads from db in batches.