### PR TITLE
printing SendTxReturnCode in logs will be more readable

### DIFF
--- a/multinode/models.go
+++ b/multinode/models.go
@@ -29,6 +29,10 @@ var sendTxSevereErrors = []SendTxReturnCode{Fatal, Underpriced, Unsupported, Exc
 // sendTxSuccessfulCodes - error codes which signal that transaction was accepted by the node
 var sendTxSuccessfulCodes = []SendTxReturnCode{Successful, TransactionAlreadyKnown}
 
+func (c SendTxReturnCode) MarshalText() ([]byte, error) {
+	return []byte(c.String()), nil
+}
+
 func (c SendTxReturnCode) String() string {
 	switch c {
 	case Successful:

--- a/multinode/transaction_sender_test.go
+++ b/multinode/transaction_sender_test.go
@@ -2,6 +2,7 @@ package multinode
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -424,4 +425,41 @@ func TestTransactionSender_SendTransaction_aggregateTxResults(t *testing.T) {
 
 func newSendTxResult(err error) sendTxResult[any] {
 	return sendTxResult[any]{error: err}
+}
+
+func TestLoggableSendTxResults(t *testing.T) {
+	t.Parallel()
+
+	// Input reconstructed from an observed production invariant violation log:
+	// 1 node returned Successful (code 1), 2 nodes returned Unknown (code 5)
+	// with "RPC call failed: TX_REPLAY_ATTACK", triggering "got success and severe error".
+	replayAttackErr := errors.New("RPC call failed: TX_REPLAY_ATTACK")
+	input := sendTxResults[any]{
+		Successful: {
+			{res: nil, code: Successful, error: nil},
+		},
+		Unknown: {
+			{res: nil, code: Unknown, error: replayAttackErr},
+			{res: nil, code: Unknown, error: replayAttackErr},
+		},
+	}
+
+	got := loggableSendTxResults(input)
+
+	require.Equal(t, map[SendTxReturnCode][]map[string]any{
+		Successful: {
+			{"res": nil, "code": Successful, "error": ""},
+		},
+		Unknown: {
+			{"res": nil, "code": Unknown, "error": "RPC call failed: TX_REPLAY_ATTACK"},
+			{"res": nil, "code": Unknown, "error": "RPC call failed: TX_REPLAY_ATTACK"},
+		},
+	}, got)
+
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	require.Equal(t,
+		`{"Successful":[{"code":"Successful","error":"","res":null}],"Unknown":[{"code":"Unknown","error":"RPC call failed: TX_REPLAY_ATTACK","res":null},{"code":"Unknown","error":"RPC call failed: TX_REPLAY_ATTACK","res":null}]}`,
+		string(b),
+	)
 }

--- a/multinode/transaction_sender_test.go
+++ b/multinode/transaction_sender_test.go
@@ -458,8 +458,28 @@ func TestLoggableSendTxResults(t *testing.T) {
 
 	b, err := json.Marshal(got)
 	require.NoError(t, err)
-	require.Equal(t,
-		`{"Successful":[{"code":"Successful","error":"","res":null}],"Unknown":[{"code":"Unknown","error":"RPC call failed: TX_REPLAY_ATTACK","res":null},{"code":"Unknown","error":"RPC call failed: TX_REPLAY_ATTACK","res":null}]}`,
+	require.JSONEq(t,
+		`{
+   "Successful":[
+      {
+         "code":"Successful",
+         "error":"",
+         "res":null
+      }
+   ],
+   "Unknown":[
+      {
+         "code":"Unknown",
+         "error":"RPC call failed: TX_REPLAY_ATTACK",
+         "res":null
+      },
+      {
+         "code":"Unknown",
+         "error":"RPC call failed: TX_REPLAY_ATTACK",
+         "res":null
+      }
+   ]
+}`,
 		string(b),
 	)
 }


### PR DESCRIPTION
### Description
When an invariant error pops up and one looks for logs either [here](https://github.com/smartcontractkit/chainlink-framework/blob/c69f27e37a13696a16e6287a407760c0c445a2cb/multinode/transaction_sender.go#L265) or [here](https://github.com/smartcontractkit/chainlink-framework/blob/c69f27e37a13696a16e6287a407760c0c445a2cb/multinode/transaction_sender.go#L290) you get `resultsByCode` printed with the numeric value insted of the enum, not fast to read

```
  "resultsByCode": {
    "1": [
      {
        "code": 1,
        "error": "",
        "res": {}
      }
    ],
    "5": [
      {
        "code": 5,
        "error": "RPC call failed: TX_REPLAY_ATTACK",
        "res": {}
      },
      {
        "code": 5,
        "error": "RPC call failed: TX_REPLAY_ATTACK",
        "res": {}
      }
    ]
  },
  "err": "found contradictions in nodes replies on SendTransaction: got success and severe error",
```

This fix will make those `resultsByCode` print in the following shape:

```
  "resultsByCode": {
    "Successful": [
      {
        "code": "Successful",
        "error": "",
        "res": {}
      }
    ],
    "Unknown": [
      {
        "code": "Unknown",
        "error": "RPC call failed: TX_REPLAY_ATTACK",
        "res": {}
      },
      {
        "code": "Unknown",
        "error": "RPC call failed: TX_REPLAY_ATTACK",
        "res": {}
      }
    ]
  },
  "err": "found contradictions in nodes replies on SendTransaction: got success and severe error",
```

<!---
  Please include a brief description of changes if not obvious from the PR title

  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
    - PR description
  
  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->