### PR TITLE
DF-23489 TestStartSendOnlyNode: deflakify assertions

### DIFF
--- a/multinode/send_only_node_test.go
+++ b/multinode/send_only_node_test.go
@@ -48,10 +48,10 @@ func TestStartSendOnlyNode(t *testing.T) {
 		s := NewSendOnlyNode(lggr, makeMockNodeMetrics(t), url.URL{}, t.Name(), RandomID(), client)
 
 		defer func() { assert.NoError(t, s.Close()) }()
+		assert.Equal(t, nodeStateUndialed, s.State())
 		err := s.Start(tests.Context(t))
 		require.NoError(t, err)
 
-		assert.Equal(t, nodeStateUndialed, s.State())
 		tests.AssertEventually(t, func() bool { return s.State() == nodeStateUnusable })
 		tests.RequireLogMessage(t, observedLogs, "Dial failed: SendOnly Node is unusable")
 	})
@@ -64,10 +64,10 @@ func TestStartSendOnlyNode(t *testing.T) {
 		s := NewSendOnlyNode(lggr, makeMockNodeMetrics(t), url.URL{}, t.Name(), NewIDFromInt(0), client)
 
 		defer func() { assert.NoError(t, s.Close()) }()
+		assert.Equal(t, nodeStateUndialed, s.State())
 		err := s.Start(tests.Context(t))
 		require.NoError(t, err)
 
-		assert.Equal(t, nodeStateUndialed, s.State())
 		tests.AssertEventually(t, func() bool { return s.State() == nodeStateAlive })
 		tests.RequireLogMessage(t, observedLogs, "sendonly rpc ChainID verification skipped")
 	})
@@ -86,10 +86,10 @@ func TestStartSendOnlyNode(t *testing.T) {
 		s := NewSendOnlyNode(lggr, metrics, url.URL{}, t.Name(), chainID, client)
 
 		defer func() { assert.NoError(t, s.Close()) }()
+		assert.Equal(t, nodeStateUndialed, s.State())
 		err := s.Start(tests.Context(t))
 		require.NoError(t, err)
 
-		assert.Equal(t, nodeStateUndialed, s.State())
 		tests.AssertEventually(t, func() bool { return s.State() == nodeStateUnreachable })
 		tests.AssertLogCountEventually(t, observedLogs, fmt.Sprintf("Verify failed: %v", expectedError), failuresCount)
 		client.On("ChainID", mock.Anything).Return(chainID, nil)
@@ -112,10 +112,10 @@ func TestStartSendOnlyNode(t *testing.T) {
 		s := NewSendOnlyNode(lggr, metrics, url.URL{}, t.Name(), configuredChainID, client)
 
 		defer func() { assert.NoError(t, s.Close()) }()
+		assert.Equal(t, nodeStateUndialed, s.State())
 		err := s.Start(tests.Context(t))
 		require.NoError(t, err)
 
-		assert.Equal(t, nodeStateUndialed, s.State())
 		tests.AssertEventually(t, func() bool { return s.State() == nodeStateInvalidChainID })
 		tests.AssertLogCountEventually(t, observedLogs, "sendonly rpc ChainID doesn't match local chain ID", failuresCount)
 		tests.AssertEventually(t, func() bool {


### PR DESCRIPTION

### Description

In `multinode`, the test `TestStartSendOnlyNode` asserts on the initial state of a node but after starting it. Trouble is `s.State` is modified in a goroutine in `Start()` and can change before the assertion, rendering it flaky.

<!---
  Please include a brief description of changes if not obvious from the PR title

  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
    - PR description
  
  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->