### PR TITLE
DF-23700 fix scale of latency for beholder + cleanups

### DIFF
--- a/metrics/client.go
+++ b/metrics/client.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	RPCCallLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name: rpcCallLatencyBeholder,
+		Name: rpcCallLatencyMetricName,
 		Help: "The duration of an RPC call in nanoseconds",
 		Buckets: []float64{
 			float64(50 * time.Millisecond),
@@ -31,7 +31,7 @@ var (
 	}, []string{"chainFamily", "chainID", "rpcUrl", "isSendOnly", "success", "rpcCallName"})
 )
 
-const rpcCallLatencyBeholder = "rpc_call_latency"
+const rpcCallLatencyMetricName = "rpc_call_latency"
 
 // RPCClientMetrics records RPC call latency to Prometheus and Beholder (failures: success="false"; same pattern as multinode metrics).
 // Construct once per chain (or process) with ChainFamily and ChainID; pass rpcUrl and isSendOnly on each call
@@ -59,7 +59,11 @@ type RPCClientMetricsConfig struct {
 
 // NewRPCClientMetrics creates RPC client metrics that publish to Prometheus and Beholder.
 func NewRPCClientMetrics(cfg RPCClientMetricsConfig) (RPCClientMetrics, error) {
-	latency, err := beholder.GetMeter().Float64Histogram(rpcCallLatencyBeholder)
+	latency, err := beholder.GetMeter().Float64Histogram(
+		rpcCallLatencyMetricName,
+		metric.WithUnit("ms"),
+		metric.WithDescription("The duration of an RPC call in milliseconds"),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to register RPC call latency metric: %w", err)
 	}
@@ -71,25 +75,23 @@ func NewRPCClientMetrics(cfg RPCClientMetricsConfig) (RPCClientMetrics, error) {
 }
 
 func (m *rpcClientMetrics) RecordRequest(ctx context.Context, rpcURL string, isSendOnly bool, callName string, latency time.Duration, err error) {
-	successStr := "true"
-	if err != nil {
-		successStr = "false"
-	}
+	successStr := strconv.FormatBool(err != nil)
 	sendStr := strconv.FormatBool(isSendOnly)
 	latencyNs := float64(latency)
 	safeRPCURL := SanitizeRPCURL(rpcURL)
 
-	RPCCallLatency.WithLabelValues(m.chainFamily, m.chainID, safeRPCURL, sendStr, successStr, callName).Observe(latencyNs)
+	RPCCallLatency.WithLabelValues(
+		m.chainFamily, m.chainID, safeRPCURL, sendStr, successStr, callName,
+	).Observe(latencyNs)
 
-	latAttrs := metric.WithAttributes(
+	m.latencyHis.Record(ctx, latencyNs/float64(time.Millisecond), metric.WithAttributes(
 		attribute.String("chainFamily", m.chainFamily),
 		attribute.String("chainID", m.chainID),
 		attribute.String("rpcUrl", safeRPCURL),
 		attribute.String("isSendOnly", sendStr),
 		attribute.String("success", successStr),
 		attribute.String("rpcCallName", callName),
-	)
-	m.latencyHis.Record(ctx, latencyNs, latAttrs)
+	))
 }
 
 // NoopRPCClientMetrics is a no-op implementation for when metrics are disabled.


### PR DESCRIPTION
### Description

Divides the latency `Duration` value by `time.Milliseconds` for the beholder latency histogram.

Cleans up implementation a bit.

### Why

Metrics are coming in all in the "+Inf" bucket. All 13162 of them.

```promql
    sum(rpc_call_latency_bucket{service_version="2.43.0", le!="+Inf"}) by (le) > 0
```

```promql
    count(rpc_call_latency_bucket{service_version="2.43.0", le!="+Inf"}) by (le) > 0
```

The default buckets, as used for the beholder histogram, are good for milliseconds so that's the idiom we're following.

<!---
  Please include a brief description of changes if not obvious from the PR title

  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
    - PR description
  
  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->