### PR TITLE
fix: Prevent Hedera same-nonce spam retries for successful txs

### DIFF
--- a/chains/txmgr/broadcaster.go
+++ b/chains/txmgr/broadcaster.go
@@ -632,10 +632,7 @@ func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) validateOnChainS
 	txSeq := *etx.Sequence
 
 	// Hedera can take several seconds before the mined nonce (latest) advances after a successful send.
-	nextSeqOnChain, err := eb.sequenceAtAfterBroadcastWithRetries(
-		ctx, lgr, etx.FromAddress, txSeq,
-		hederaDefaultSequencePollInterval, hederaDefaultSequencePollRetries,
-	)
+	nextSeqOnChain, err := eb.sequenceAtAfterBroadcastWithRetries(ctx, lgr, etx.FromAddress, txSeq)
 	if err != nil {
 		return errType, err
 	}
@@ -670,11 +667,9 @@ func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) sequenceAtAfterB
 	lgr logger.SugaredLogger,
 	fromAddress ADDR,
 	txSeq SEQ,
-	pollInterval time.Duration,
-	maxPollRetries int,
 ) (SEQ, error) {
 	var nextSeqOnChain SEQ
-	_, err := pollSequenceAtAfterBroadcast(ctx, lgr, txSeq.Int64(), pollInterval, maxPollRetries,
+	_, err := pollSequenceAtAfterBroadcast(ctx, lgr, txSeq.Int64(), hederaDefaultSequencePollInterval, hederaDefaultSequencePollRetries,
 		func(ctx context.Context) (int64, error) {
 			var err error
 			nextSeqOnChain, err = eb.client.SequenceAt(ctx, fromAddress, nil)

--- a/chains/txmgr/broadcaster.go
+++ b/chains/txmgr/broadcaster.go
@@ -33,8 +33,16 @@ const (
 	// spent on the transmit check.
 	TransmitCheckTimeout = 2 * time.Second
 
-	// maxBroadcastRetries is the number of times a transaction broadcast is retried when the sequence fails to increment on Hedera
+	// maxHederaBroadcastRetries is the number of times a transaction broadcast is retried with a bumped fee
+	// when the mined sequence still has not advanced after polling.
 	maxHederaBroadcastRetries = 3
+
+	// hederaDefaultSequencePollInterval is the delay between Hedera SequenceAt re-polls after a successful send.
+	hederaDefaultSequencePollInterval = 10 * time.Second
+
+	// hederaDefaultSequencePollRetries is the number of SequenceAt re-polls (after the initial check)
+	// before treating the broadcast as underpriced on Hedera.
+	hederaDefaultSequencePollRetries = 3
 
 	// hederaChainType is the string representation of the Hedera chain type
 	// Temporary solution until the Broadcaster is moved to the EVM code base
@@ -623,18 +631,11 @@ func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) validateOnChainS
 	// Transaction sequence cannot be nil here since a sequence is required to broadcast
 	txSeq := *etx.Sequence
 
-	// Hedera accepts txs into its mempool before the mined nonce (latest) advances.
-	// Pending reflects acceptance; latest can lag by several seconds.
-	nextSeqPending, err := eb.client.PendingSequenceAt(ctx, etx.FromAddress)
-	if err != nil {
-		return errType, err
-	}
-	if nextSeqPending.Int64() > txSeq.Int64() {
-		return multinode.Successful, nil
-	}
-
-	// Retrieve the latest mined sequence from on-chain
-	nextSeqOnChain, err := eb.client.SequenceAt(ctx, etx.FromAddress, nil)
+	// Hedera can take several seconds before the mined nonce (latest) advances after a successful send.
+	nextSeqOnChain, err := eb.sequenceAtAfterBroadcastWithRetries(
+		ctx, lgr, etx.FromAddress, txSeq,
+		hederaDefaultSequencePollInterval, hederaDefaultSequencePollRetries,
+	)
 	if err != nil {
 		return errType, err
 	}
@@ -662,6 +663,41 @@ func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) validateOnChainS
 	}
 
 	return multinode.Successful, nil
+}
+
+func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) sequenceAtAfterBroadcastWithRetries(
+	ctx context.Context,
+	lgr logger.SugaredLogger,
+	fromAddress ADDR,
+	txSeq SEQ,
+	pollInterval time.Duration,
+	maxPollRetries int,
+) (SEQ, error) {
+	var nextSeqOnChain SEQ
+	for poll := 0; poll <= maxPollRetries; poll++ {
+		if poll > 0 {
+			lgr.Infow("Hedera mined sequence not yet advanced, waiting before re-check",
+				"delay", pollInterval,
+				"poll", poll,
+				"maxPolls", maxPollRetries,
+			)
+			select {
+			case <-ctx.Done():
+				return nextSeqOnChain, ctx.Err()
+			case <-time.After(pollInterval):
+			}
+		}
+
+		var err error
+		nextSeqOnChain, err = eb.client.SequenceAt(ctx, fromAddress, nil)
+		if err != nil {
+			return nextSeqOnChain, err
+		}
+		if nextSeqOnChain.Int64() > txSeq.Int64() {
+			return nextSeqOnChain, nil
+		}
+	}
+	return nextSeqOnChain, nil
 }
 
 // Finds next transaction in the queue, assigns a sequence, and moves it to "in_progress" state ready for broadcast.

--- a/chains/txmgr/broadcaster.go
+++ b/chains/txmgr/broadcaster.go
@@ -674,6 +674,30 @@ func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) sequenceAtAfterB
 	maxPollRetries int,
 ) (SEQ, error) {
 	var nextSeqOnChain SEQ
+	_, err := pollSequenceAtAfterBroadcast(ctx, lgr, txSeq.Int64(), pollInterval, maxPollRetries,
+		func(ctx context.Context) (int64, error) {
+			var err error
+			nextSeqOnChain, err = eb.client.SequenceAt(ctx, fromAddress, nil)
+			if err != nil {
+				return 0, err
+			}
+			return nextSeqOnChain.Int64(), nil
+		},
+	)
+	return nextSeqOnChain, err
+}
+
+// pollSequenceAtAfterBroadcast polls sequenceAt until the value exceeds txSeq, waiting pollInterval
+// between attempts up to maxPollRetries times after the initial check.
+func pollSequenceAtAfterBroadcast(
+	ctx context.Context,
+	lgr logger.SugaredLogger,
+	txSeq int64,
+	pollInterval time.Duration,
+	maxPollRetries int,
+	sequenceAt func(ctx context.Context) (int64, error),
+) (int64, error) {
+	var nextSeqOnChain int64
 	for poll := 0; poll <= maxPollRetries; poll++ {
 		if poll > 0 {
 			lgr.Infow("Hedera mined sequence not yet advanced, waiting before re-check",
@@ -689,11 +713,11 @@ func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) sequenceAtAfterB
 		}
 
 		var err error
-		nextSeqOnChain, err = eb.client.SequenceAt(ctx, fromAddress, nil)
+		nextSeqOnChain, err = sequenceAt(ctx)
 		if err != nil {
 			return nextSeqOnChain, err
 		}
-		if nextSeqOnChain.Int64() > txSeq.Int64() {
+		if nextSeqOnChain > txSeq {
 			return nextSeqOnChain, nil
 		}
 	}

--- a/chains/txmgr/broadcaster.go
+++ b/chains/txmgr/broadcaster.go
@@ -37,12 +37,9 @@ const (
 	// when the mined sequence still has not advanced after polling.
 	maxHederaBroadcastRetries = 3
 
-	// hederaDefaultSequencePollInterval is the delay between Hedera SequenceAt re-polls after a successful send.
-	hederaDefaultSequencePollInterval = 10 * time.Second
-
-	// hederaDefaultSequencePollRetries is the number of SequenceAt re-polls (after the initial check)
-	// before treating the broadcast as underpriced on Hedera.
-	hederaDefaultSequencePollRetries = 3
+	// hederaDefaultSequencePollInterval is the delay between Hedera SequenceAt re-polls when polling is enabled
+	// and no interval is configured.
+	hederaDefaultSequencePollInterval = 2 * time.Second
 
 	// hederaChainType is the string representation of the Hedera chain type
 	// Temporary solution until the Broadcaster is moved to the EVM code base
@@ -668,8 +665,9 @@ func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) sequenceAtAfterB
 	fromAddress ADDR,
 	txSeq SEQ,
 ) (SEQ, error) {
+	pollInterval, pollTimeout := eb.hederaSequencePollConfig()
 	var nextSeqOnChain SEQ
-	_, err := pollSequenceAtAfterBroadcast(ctx, lgr, txSeq.Int64(), hederaDefaultSequencePollInterval, hederaDefaultSequencePollRetries,
+	_, err := pollSequenceAtAfterBroadcast(ctx, lgr, txSeq.Int64(), pollInterval, pollTimeout,
 		func(ctx context.Context) (int64, error) {
 			var err error
 			nextSeqOnChain, err = eb.client.SequenceAt(ctx, fromAddress, nil)
@@ -682,32 +680,68 @@ func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) sequenceAtAfterB
 	return nextSeqOnChain, err
 }
 
-// pollSequenceAtAfterBroadcast polls sequenceAt until the value exceeds txSeq, waiting pollInterval
-// between attempts up to maxPollRetries times after the initial check.
+// hederaSequencePollConfig returns polling settings for Hedera post-send sequence validation.
+// Polling is disabled unless txConfig implements HederaBroadcastConfig with a positive timeout.
+func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) hederaSequencePollConfig() (pollInterval time.Duration, pollTimeout time.Duration) {
+	if eb.chainType != hederaChainType {
+		return 0, 0
+	}
+	cfg, ok := eb.txConfig.(types.HederaBroadcastConfig)
+	if !ok {
+		return 0, 0
+	}
+	timeout := cfg.HederaSequencePollTimeout()
+	if timeout == nil || *timeout <= 0 {
+		return 0, 0
+	}
+
+	interval := hederaDefaultSequencePollInterval
+	if v := cfg.HederaSequencePollInterval(); v != nil && *v > 0 {
+		interval = *v
+	}
+	return interval, *timeout
+}
+
+// pollSequenceAtAfterBroadcast polls sequenceAt until the value exceeds txSeq or pollTimeout elapses.
+// When pollTimeout is zero, only a single immediate check is performed (legacy behavior).
 func pollSequenceAtAfterBroadcast(
 	ctx context.Context,
 	lgr logger.SugaredLogger,
 	txSeq int64,
 	pollInterval time.Duration,
-	maxPollRetries int,
+	pollTimeout time.Duration,
 	sequenceAt func(ctx context.Context) (int64, error),
 ) (int64, error) {
 	var nextSeqOnChain int64
-	for poll := 0; poll <= maxPollRetries; poll++ {
-		if poll > 0 {
-			lgr.Infow("Hedera mined sequence not yet advanced, waiting before re-check",
-				"delay", pollInterval,
-				"poll", poll,
-				"maxPolls", maxPollRetries,
-			)
-			select {
-			case <-ctx.Done():
-				return nextSeqOnChain, ctx.Err()
-			case <-time.After(pollInterval):
-			}
+	nextSeqOnChain, err := sequenceAt(ctx)
+	if err != nil {
+		return nextSeqOnChain, err
+	}
+	if nextSeqOnChain > txSeq || pollTimeout <= 0 {
+		return nextSeqOnChain, nil
+	}
+
+	deadline := time.Now().Add(pollTimeout)
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nextSeqOnChain, nil
 		}
 
-		var err error
+		wait := pollInterval
+		if wait > remaining {
+			wait = remaining
+		}
+		lgr.Infow("Hedera mined sequence not yet advanced, waiting before re-check",
+			"delay", wait,
+			"remaining", remaining,
+		)
+		select {
+		case <-ctx.Done():
+			return nextSeqOnChain, ctx.Err()
+		case <-time.After(wait):
+		}
+
 		nextSeqOnChain, err = sequenceAt(ctx)
 		if err != nil {
 			return nextSeqOnChain, err
@@ -716,7 +750,6 @@ func pollSequenceAtAfterBroadcast(
 			return nextSeqOnChain, nil
 		}
 	}
-	return nextSeqOnChain, nil
 }
 
 // Finds next transaction in the queue, assigns a sequence, and moves it to "in_progress" state ready for broadcast.

--- a/chains/txmgr/broadcaster.go
+++ b/chains/txmgr/broadcaster.go
@@ -622,6 +622,17 @@ func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) validateOnChainS
 	}
 	// Transaction sequence cannot be nil here since a sequence is required to broadcast
 	txSeq := *etx.Sequence
+
+	// Hedera accepts txs into its mempool before the mined nonce (latest) advances.
+	// Pending reflects acceptance; latest can lag by several seconds.
+	nextSeqPending, err := eb.client.PendingSequenceAt(ctx, etx.FromAddress)
+	if err != nil {
+		return errType, err
+	}
+	if nextSeqPending.Int64() > txSeq.Int64() {
+		return multinode.Successful, nil
+	}
+
 	// Retrieve the latest mined sequence from on-chain
 	nextSeqOnChain, err := eb.client.SequenceAt(ctx, etx.FromAddress, nil)
 	if err != nil {

--- a/chains/txmgr/broadcaster_hedera_test.go
+++ b/chains/txmgr/broadcaster_hedera_test.go
@@ -1,0 +1,97 @@
+package txmgr
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+func TestPollSequenceAtAfterBroadcast(t *testing.T) {
+	t.Parallel()
+
+	lgr := logger.Sugared(logger.Test(t))
+	pollInterval := 5 * time.Millisecond
+
+	t.Run("returns immediately when sequence already advanced", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+		start := time.Now()
+
+		got, err := pollSequenceAtAfterBroadcast(
+			t.Context(), lgr, 85, pollInterval, 3,
+			func(context.Context) (int64, error) {
+				calls.Add(1)
+				return 86, nil
+			},
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(86), got)
+		assert.Equal(t, int32(1), calls.Load())
+		assert.Less(t, time.Since(start), pollInterval)
+	})
+
+	t.Run("waits and polls until sequence advances", func(t *testing.T) {
+		t.Parallel()
+
+		sequences := []int64{85, 85, 86}
+		var calls atomic.Int32
+		start := time.Now()
+
+		got, err := pollSequenceAtAfterBroadcast(
+			t.Context(), lgr, 85, pollInterval, 3,
+			func(context.Context) (int64, error) {
+				i := int(calls.Add(1)) - 1
+				return sequences[i], nil
+			},
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(86), got)
+		assert.Equal(t, int32(3), calls.Load())
+		assert.GreaterOrEqual(t, time.Since(start), 2*pollInterval)
+	})
+
+	t.Run("returns last sequence when it never advances", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+		start := time.Now()
+
+		got, err := pollSequenceAtAfterBroadcast(
+			t.Context(), lgr, 85, pollInterval, 3,
+			func(context.Context) (int64, error) {
+				calls.Add(1)
+				return 85, nil
+			},
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(85), got)
+		assert.Equal(t, int32(4), calls.Load())
+		assert.GreaterOrEqual(t, time.Since(start), 3*pollInterval)
+	})
+
+	t.Run("returns context error while waiting", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		_, err := pollSequenceAtAfterBroadcast(
+			ctx, lgr, 85, pollInterval, 3,
+			func(context.Context) (int64, error) {
+				return 85, nil
+			},
+		)
+
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}

--- a/chains/txmgr/broadcaster_hedera_test.go
+++ b/chains/txmgr/broadcaster_hedera_test.go
@@ -18,6 +18,24 @@ func TestPollSequenceAtAfterBroadcast(t *testing.T) {
 	lgr := logger.Sugared(logger.Test(t))
 	pollInterval := 5 * time.Millisecond
 
+	t.Run("legacy single check when polling disabled", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+
+		got, err := pollSequenceAtAfterBroadcast(
+			t.Context(), lgr, 85, pollInterval, 0,
+			func(context.Context) (int64, error) {
+				calls.Add(1)
+				return 85, nil
+			},
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(85), got)
+		assert.Equal(t, int32(1), calls.Load())
+	})
+
 	t.Run("returns immediately when sequence already advanced", func(t *testing.T) {
 		t.Parallel()
 
@@ -25,7 +43,7 @@ func TestPollSequenceAtAfterBroadcast(t *testing.T) {
 		start := time.Now()
 
 		got, err := pollSequenceAtAfterBroadcast(
-			t.Context(), lgr, 85, pollInterval, 3,
+			t.Context(), lgr, 85, pollInterval, 20*time.Millisecond,
 			func(context.Context) (int64, error) {
 				calls.Add(1)
 				return 86, nil
@@ -46,7 +64,7 @@ func TestPollSequenceAtAfterBroadcast(t *testing.T) {
 		start := time.Now()
 
 		got, err := pollSequenceAtAfterBroadcast(
-			t.Context(), lgr, 85, pollInterval, 3,
+			t.Context(), lgr, 85, pollInterval, 20*time.Millisecond,
 			func(context.Context) (int64, error) {
 				i := int(calls.Add(1)) - 1
 				return sequences[i], nil
@@ -59,14 +77,15 @@ func TestPollSequenceAtAfterBroadcast(t *testing.T) {
 		assert.GreaterOrEqual(t, time.Since(start), 2*pollInterval)
 	})
 
-	t.Run("returns last sequence when it never advances", func(t *testing.T) {
+	t.Run("returns last sequence when it never advances before timeout", func(t *testing.T) {
 		t.Parallel()
 
 		var calls atomic.Int32
 		start := time.Now()
+		pollTimeout := 15 * time.Millisecond
 
 		got, err := pollSequenceAtAfterBroadcast(
-			t.Context(), lgr, 85, pollInterval, 3,
+			t.Context(), lgr, 85, pollInterval, pollTimeout,
 			func(context.Context) (int64, error) {
 				calls.Add(1)
 				return 85, nil
@@ -75,8 +94,8 @@ func TestPollSequenceAtAfterBroadcast(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, int64(85), got)
-		assert.Equal(t, int32(4), calls.Load())
-		assert.GreaterOrEqual(t, time.Since(start), 3*pollInterval)
+		assert.GreaterOrEqual(t, calls.Load(), int32(2))
+		assert.LessOrEqual(t, time.Since(start), pollTimeout+pollInterval)
 	})
 
 	t.Run("returns context error while waiting", func(t *testing.T) {
@@ -86,7 +105,7 @@ func TestPollSequenceAtAfterBroadcast(t *testing.T) {
 		cancel()
 
 		_, err := pollSequenceAtAfterBroadcast(
-			ctx, lgr, 85, pollInterval, 3,
+			ctx, lgr, 85, pollInterval, 20*time.Millisecond,
 			func(context.Context) (int64, error) {
 				return 85, nil
 			},

--- a/chains/txmgr/types/config.go
+++ b/chains/txmgr/types/config.go
@@ -34,6 +34,18 @@ type BroadcasterTransactionsConfig interface {
 	MaxInFlight() uint32
 }
 
+// HederaBroadcastConfig is an optional interface implemented by txConfig.
+// When HederaSequencePollTimeout is unset or zero, the broadcaster keeps legacy behavior:
+// a single immediate SequenceAt check after a successful send with no polling backoff.
+type HederaBroadcastConfig interface {
+	// HederaSequencePollTimeout is the total time to wait for the mined nonce to advance.
+	// Nil or zero disables polling (legacy behavior).
+	HederaSequencePollTimeout() *time.Duration
+	// HederaSequencePollInterval is the delay between SequenceAt checks while polling.
+	// Nil uses the framework default. Ignored when polling is disabled.
+	HederaSequencePollInterval() *time.Duration
+}
+
 type BroadcasterListenerConfig interface {
 	FallbackPollInterval() time.Duration
 }


### PR DESCRIPTION
## Problem

On Hedera, after a successful `eth_sendRawTransaction`, TXM runs `validateOnChainSequence`. That reads the mined nonce via `SequenceAt` (`eth_getTransactionCount` with `latest`). If the count is still equal to the tx nonce, TXM treats the send as underpriced and immediately gas-bumps with the **same nonce** — up to 3 times, no sleep between attempts.

Where this happens in code:

- Hedera post-send check is triggered from [`handleInProgressTx`](https://github.com/smartcontractkit/chainlink-framework/blob/d9a5c57f9729203a4b973c4d937ceea0966e4dec/chains/txmgr/broadcaster.go#L486-L488) → [`validateOnChainSequence`](https://github.com/smartcontractkit/chainlink-framework/blob/d9a5c57f9729203a4b973c4d937ceea0966e4dec/chains/txmgr/broadcaster.go#L627)
- Today it checks [`SequenceAt`](https://github.com/smartcontractkit/chainlink-framework/blob/d9a5c57f9729203a4b973c4d937ceea0966e4dec/chains/txmgr/broadcaster.go#L636-L639) once, immediately after send
- A match triggers gas-bump retry via [`Underpriced`](https://github.com/smartcontractkit/chainlink-framework/blob/d9a5c57f9729203a4b973c4d937ceea0966e4dec/chains/txmgr/broadcaster.go#L647-L648)

On Hedera, the mined nonce can lag several seconds behind RPC acceptance. The immediate check is too eager.

This matches what we see on Hedera mainnet: bursts of same-nonce OffRamp txs (WRONG_NONCE) a second or two apart.

## What we tested

We sent a zero-value self-transfer and checked `latest` and `pending` immediately after the RPC accepted the send.

**Testnet** (tx nonce 227):

- `latest`: 227 — unchanged
- `pending`: 228 — bumped
- Current TXM would retry immediately
- `latest` caught up to 228 after ~7.4s

**Mainnet** (tx nonce 85):

- `latest`: 85 — unchanged
- `pending`: 86 — bumped
- Same outcome: current TXM would retry immediately
- `latest` caught up to 86 after ~9.7s

Same pattern on both: RPC accepts the tx right away, but `latest` lags by several seconds.

## Fix

Before falling back to the gas-bump path, poll `SequenceAt` with backoff:

- Initial check immediately after send
- Up to 3 more checks, **10s apart**
- If `latest` advances during polling → treat broadcast as successful (no resend)
- If still flat after ~30s → existing `Underpriced` / gas-bump retry path

Implemented in [`sequenceAtAfterBroadcastWithRetries`](https://github.com/smartcontractkit/chainlink-framework/blob/d9a5c57f9729203a4b973c4d937ceea0966e4dec/chains/txmgr/broadcaster.go#L673).

## Note: why not `pending`?

We also tried accepting the broadcast when `eth_getTransactionCount(addr, "pending")` advanced before `latest` did. That fixed the false-positive retries in our repro, but we did not ship it.

If we treat a bumped `pending` as success, we skip the gas-bump retry path entirely. In cases where the tx was not actually accepted — both `pending` and `latest` stay flat — we would never reach `Underpriced` and the tx could sit in `in_progress` indefinitely instead of recovering via a bumped resend.

Polling `latest` with backoff keeps the existing escape hatch: wait out normal Hedera lag, but still gas-bump if the mined nonce never moves.