### PR TITLE
Bugfix/ccip 11890 executor OOF metrics

### DIFF
--- a/chains/txmgr/broadcaster.go
+++ b/chains/txmgr/broadcaster.go
@@ -64,7 +64,7 @@ type TransmitChecker[CID chains.ID, ADDR chains.Hashable, THASH, BHASH chains.Ha
 type broadcasterMetrics interface {
 	IncrementNumBroadcastedTxs(ctx context.Context)
 	RecordTimeUntilTxBroadcast(ctx context.Context, duration float64)
-	IncrementNumInsufficientFundsTxs(ctx context.Context, fromAddress string)
+	IncrementNumInsufficientFundsForTx(ctx context.Context, senderAddress string)
 }
 
 // Broadcaster monitors txes for transactions that need to
@@ -553,8 +553,8 @@ func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) handleInProgress
 		// replace the current attempt, and retry after the backoff duration.
 		// The new attempt must be replaced immediately because of a database constraint.
 		eb.SvcErrBuffer.Append(err)
-		eb.metrics.IncrementNumInsufficientFundsTxs(ctx, etx.FromAddress.String())
-		lgr.Warnw("Transaction rejected due to insufficient funds in sending address, will retry", "fromAddress", etx.FromAddress.String(), "err", err)
+		eb.metrics.IncrementNumInsufficientFundsForTx(ctx, etx.FromAddress.String())
+		lgr.Warnw("Transaction rejected due to insufficient funds in sending address, will retry", "senderAddress", etx.FromAddress.String(), "err", err)
 		if _, _, replaceErr := eb.replaceAttemptWithNewEstimation(ctx, lgr, etx, attempt); replaceErr != nil {
 			return replaceErr, true
 		}

--- a/chains/txmgr/broadcaster.go
+++ b/chains/txmgr/broadcaster.go
@@ -554,7 +554,7 @@ func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) handleInProgress
 		// The new attempt must be replaced immediately because of a database constraint.
 		eb.SvcErrBuffer.Append(err)
 		eb.metrics.IncrementNumInsufficientFundsForTx(ctx, etx.FromAddress.String())
-		lgr.Warnw("Transaction rejected due to insufficient funds in sending address, will retry", "senderAddress", etx.FromAddress.String(), "err", err)
+		lgr.Warnw("Transaction rejected due to insufficient funds in sending address, will retry", "fromAddress", etx.FromAddress.String(), "err", err)
 		if _, _, replaceErr := eb.replaceAttemptWithNewEstimation(ctx, lgr, etx, attempt); replaceErr != nil {
 			return replaceErr, true
 		}

--- a/chains/txmgr/broadcaster.go
+++ b/chains/txmgr/broadcaster.go
@@ -64,7 +64,7 @@ type TransmitChecker[CID chains.ID, ADDR chains.Hashable, THASH, BHASH chains.Ha
 type broadcasterMetrics interface {
 	IncrementNumBroadcastedTxs(ctx context.Context)
 	RecordTimeUntilTxBroadcast(ctx context.Context, duration float64)
-	IncrementNumInsufficientFundsForTx(ctx context.Context, senderAddress string)
+	IncrementNumInsufficientFundsForTx(ctx context.Context, fromAddress string)
 }
 
 // Broadcaster monitors txes for transactions that need to

--- a/chains/txmgr/broadcaster.go
+++ b/chains/txmgr/broadcaster.go
@@ -53,7 +53,6 @@ type TransmitCheckerFactory[CID chains.ID, ADDR chains.Hashable, THASH, BHASH ch
 
 // TransmitChecker determines whether a transaction should be submitted on-chain.
 type TransmitChecker[CID chains.ID, ADDR chains.Hashable, THASH, BHASH chains.Hashable, SEQ chains.Sequence, FEE fees.Fee] interface {
-
 	// Check the given transaction. If the transaction should not be sent, an error indicating why
 	// is returned. Errors should only be returned if the checker can confirm that a transaction
 	// should not be sent, other errors (for example connection or other unexpected errors) should
@@ -554,7 +553,7 @@ func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) handleInProgress
 		// The new attempt must be replaced immediately because of a database constraint.
 		eb.SvcErrBuffer.Append(err)
 		eb.metrics.IncrementNumInsufficientFundsForTx(ctx, etx.FromAddress.String())
-		lgr.Warnw("Transaction rejected due to insufficient funds in sending address, will retry", "fromAddress", etx.FromAddress.String(), "err", err)
+		lgr.Warnw("Transaction rejected due to insufficient funds at sending address, will retry", "fromAddress", etx.FromAddress.String(), "err", err)
 		if _, _, replaceErr := eb.replaceAttemptWithNewEstimation(ctx, lgr, etx, attempt); replaceErr != nil {
 			return replaceErr, true
 		}
@@ -682,7 +681,8 @@ func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) nextUnstartedTra
 func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) replaceAttemptWithBumpedGas(ctx context.Context, lgr logger.Logger, txError error, etx types.Tx[CID, ADDR, THASH, BHASH, SEQ, FEE], attempt types.TxAttempt[CID, ADDR, THASH, BHASH, SEQ, FEE]) (replacedAttempt types.TxAttempt[CID, ADDR, THASH, BHASH, SEQ, FEE], retryable bool, err error) {
 	// This log error is not applicable to Hedera since the action required would not be needed for its gas estimator
 	if eb.chainType != hederaChainType {
-		logger.With(lgr,
+		logger.With(
+			lgr,
 			"sendError", txError,
 			"attemptFee", attempt.TxFee,
 			"maxGasPriceConfig", eb.feeConfig.MaxFeePrice(),

--- a/chains/txmgr/broadcaster.go
+++ b/chains/txmgr/broadcaster.go
@@ -64,6 +64,7 @@ type TransmitChecker[CID chains.ID, ADDR chains.Hashable, THASH, BHASH chains.Ha
 type broadcasterMetrics interface {
 	IncrementNumBroadcastedTxs(ctx context.Context)
 	RecordTimeUntilTxBroadcast(ctx context.Context, duration float64)
+	IncrementNumInsufficientFundsTxs(ctx context.Context, fromAddress string)
 }
 
 // Broadcaster monitors txes for transactions that need to
@@ -552,6 +553,8 @@ func (eb *Broadcaster[CID, HEAD, ADDR, THASH, BHASH, SEQ, FEE]) handleInProgress
 		// replace the current attempt, and retry after the backoff duration.
 		// The new attempt must be replaced immediately because of a database constraint.
 		eb.SvcErrBuffer.Append(err)
+		eb.metrics.IncrementNumInsufficientFundsTxs(ctx, etx.FromAddress.String())
+		lgr.Warnw("Transaction rejected due to insufficient funds in sending address, will retry", "fromAddress", etx.FromAddress.String(), "err", err)
 		if _, _, replaceErr := eb.replaceAttemptWithNewEstimation(ctx, lgr, etx, attempt); replaceErr != nil {
 			return replaceErr, true
 		}

--- a/chains/txmgr/confirmer.go
+++ b/chains/txmgr/confirmer.go
@@ -37,6 +37,7 @@ type confimerMetrics interface {
 	IncrementNumConfirmedTxs(ctx context.Context, confirmedTransactions int)
 	RecordTimeUntilTxConfirmed(ctx context.Context, duration float64)
 	RecordBlocksUntilTxConfirmed(ctx context.Context, blocksElapsed float64)
+	IncrementNumInsufficientFundsTxs(ctx context.Context, fromAddress string)
 }
 
 // Confirmer is a broad service which performs four different tasks in sequence on every new longest chain
@@ -754,6 +755,7 @@ func (ec *Confirmer[CID, HEAD, ADDR, THASH, BHASH, R, SEQ, FEE]) handleInProgres
 		timeout := ec.dbConfig.DefaultQueryTimeout()
 		return ec.txStore.SaveConfirmedAttempt(ctx, timeout, &attempt, now)
 	case multinode.InsufficientFunds:
+		ec.metrics.IncrementNumInsufficientFundsTxs(ctx, etx.FromAddress.String())
 		timeout := ec.dbConfig.DefaultQueryTimeout()
 		return ec.txStore.SaveInsufficientFundsAttempt(ctx, timeout, &attempt, now)
 	case multinode.Successful:

--- a/chains/txmgr/confirmer.go
+++ b/chains/txmgr/confirmer.go
@@ -37,7 +37,7 @@ type confimerMetrics interface {
 	IncrementNumConfirmedTxs(ctx context.Context, confirmedTransactions int)
 	RecordTimeUntilTxConfirmed(ctx context.Context, duration float64)
 	RecordBlocksUntilTxConfirmed(ctx context.Context, blocksElapsed float64)
-	IncrementNumInsufficientFundsForTx(ctx context.Context, senderAddress string)
+	IncrementNumInsufficientFundsForTx(ctx context.Context, fromAddress string)
 }
 
 // Confirmer is a broad service which performs four different tasks in sequence on every new longest chain

--- a/chains/txmgr/confirmer.go
+++ b/chains/txmgr/confirmer.go
@@ -37,7 +37,7 @@ type confimerMetrics interface {
 	IncrementNumConfirmedTxs(ctx context.Context, confirmedTransactions int)
 	RecordTimeUntilTxConfirmed(ctx context.Context, duration float64)
 	RecordBlocksUntilTxConfirmed(ctx context.Context, blocksElapsed float64)
-	IncrementNumInsufficientFundsTxs(ctx context.Context, fromAddress string)
+	IncrementNumInsufficientFundsForTx(ctx context.Context, senderAddress string)
 }
 
 // Confirmer is a broad service which performs four different tasks in sequence on every new longest chain
@@ -755,7 +755,7 @@ func (ec *Confirmer[CID, HEAD, ADDR, THASH, BHASH, R, SEQ, FEE]) handleInProgres
 		timeout := ec.dbConfig.DefaultQueryTimeout()
 		return ec.txStore.SaveConfirmedAttempt(ctx, timeout, &attempt, now)
 	case multinode.InsufficientFunds:
-		ec.metrics.IncrementNumInsufficientFundsTxs(ctx, etx.FromAddress.String())
+		ec.metrics.IncrementNumInsufficientFundsForTx(ctx, etx.FromAddress.String())
 		timeout := ec.dbConfig.DefaultQueryTimeout()
 		return ec.txStore.SaveInsufficientFundsAttempt(ctx, timeout, &attempt, now)
 	case multinode.Successful:

--- a/metrics/txm.go
+++ b/metrics/txm.go
@@ -71,6 +71,10 @@ var (
 			float64(100),
 		},
 	}, []string{"chainID"})
+	promNumInsufficientFunds = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "tx_manager_insufficient_funds_tx_count",
+		Help: "Number of transaction broadcast attempts rejected by an RPC node because the sending address had insufficient funds. Increments on every retry while the address remains underfunded, so a sustained rate indicates the address needs topping up.",
+	}, []string{"chainID", "fromAddress"})
 )
 
 type GenericTXMMetrics interface {
@@ -81,6 +85,7 @@ type GenericTXMMetrics interface {
 	IncrementNumConfirmedTxs(ctx context.Context, confirmedTransactions int)
 	RecordTimeUntilTxConfirmed(ctx context.Context, duration float64)
 	RecordBlocksUntilTxConfirmed(ctx context.Context, blocksElapsed float64)
+	IncrementNumInsufficientFundsTxs(ctx context.Context, fromAddress string)
 }
 
 type txmMetrics struct {
@@ -92,6 +97,7 @@ type txmMetrics struct {
 	numConfirmedTxs        metric.Int64Counter
 	timeUntilTxConfirmed   metric.Float64Histogram
 	blocksUntilTxConfirmed metric.Float64Histogram
+	numInsufficientFundsTxs metric.Int64Counter
 }
 
 func NewGenericTxmMetrics(chainID string) (GenericTXMMetrics, error) {
@@ -130,6 +136,11 @@ func NewGenericTxmMetrics(chainID string) (GenericTXMMetrics, error) {
 		return nil, fmt.Errorf("failed to register blocks until tx confirmed metric: %w", err)
 	}
 
+	numInsufficientFundsTxs, err := beholder.GetMeter().Int64Counter("tx_manager_insufficient_funds_tx_count")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register insufficient funds txs metric: %w", err)
+	}
+
 	return &txmMetrics{
 		chainID:                chainID,
 		numBroadcastedTxs:      numBroadcastedTxs,
@@ -139,6 +150,7 @@ func NewGenericTxmMetrics(chainID string) (GenericTXMMetrics, error) {
 		numConfirmedTxs:        numConfirmedTxs,
 		timeUntilTxConfirmed:   timeUntilTxConfirmed,
 		blocksUntilTxConfirmed: blocksUntilTxConfirmed,
+		numInsufficientFundsTxs: numInsufficientFundsTxs,
 	}, nil
 }
 
@@ -175,4 +187,12 @@ func (m *txmMetrics) RecordTimeUntilTxConfirmed(ctx context.Context, duration fl
 func (m *txmMetrics) RecordBlocksUntilTxConfirmed(ctx context.Context, blocksElapsed float64) {
 	promBlocksUntilTxConfirmed.WithLabelValues(m.chainID).Observe(blocksElapsed)
 	m.blocksUntilTxConfirmed.Record(ctx, blocksElapsed, metric.WithAttributes(attribute.String("chainID", m.chainID)))
+}
+
+func (m *txmMetrics) IncrementNumInsufficientFundsTxs(ctx context.Context, fromAddress string) {
+	promNumInsufficientFunds.WithLabelValues(m.chainID, fromAddress).Add(1)
+	m.numInsufficientFundsTxs.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("chainID", m.chainID),
+		attribute.String("fromAddress", fromAddress),
+	))
 }

--- a/metrics/txm.go
+++ b/metrics/txm.go
@@ -89,14 +89,14 @@ type GenericTXMMetrics interface {
 }
 
 type txmMetrics struct {
-	chainID                string
-	numBroadcastedTxs      metric.Int64Counter
-	timeUntilBroadcast     metric.Float64Histogram
-	numGasBumps            metric.Int64Counter
-	gasBumpExceedsLimit    metric.Int64Counter
-	numConfirmedTxs        metric.Int64Counter
-	timeUntilTxConfirmed   metric.Float64Histogram
-	blocksUntilTxConfirmed metric.Float64Histogram
+	chainID                 string
+	numBroadcastedTxs       metric.Int64Counter
+	timeUntilBroadcast      metric.Float64Histogram
+	numGasBumps             metric.Int64Counter
+	gasBumpExceedsLimit     metric.Int64Counter
+	numConfirmedTxs         metric.Int64Counter
+	timeUntilTxConfirmed    metric.Float64Histogram
+	blocksUntilTxConfirmed  metric.Float64Histogram
 	numInsufficientFundsTxs metric.Int64Counter
 }
 
@@ -142,14 +142,14 @@ func NewGenericTxmMetrics(chainID string) (GenericTXMMetrics, error) {
 	}
 
 	return &txmMetrics{
-		chainID:                chainID,
-		numBroadcastedTxs:      numBroadcastedTxs,
-		timeUntilBroadcast:     timeUntilBroadcast,
-		numGasBumps:            numGasBumps,
-		gasBumpExceedsLimit:    gasBumpExceedsLimit,
-		numConfirmedTxs:        numConfirmedTxs,
-		timeUntilTxConfirmed:   timeUntilTxConfirmed,
-		blocksUntilTxConfirmed: blocksUntilTxConfirmed,
+		chainID:                 chainID,
+		numBroadcastedTxs:       numBroadcastedTxs,
+		timeUntilBroadcast:      timeUntilBroadcast,
+		numGasBumps:             numGasBumps,
+		gasBumpExceedsLimit:     gasBumpExceedsLimit,
+		numConfirmedTxs:         numConfirmedTxs,
+		timeUntilTxConfirmed:    timeUntilTxConfirmed,
+		blocksUntilTxConfirmed:  blocksUntilTxConfirmed,
 		numInsufficientFundsTxs: numInsufficientFundsTxs,
 	}, nil
 }

--- a/metrics/txm.go
+++ b/metrics/txm.go
@@ -74,7 +74,7 @@ var (
 	promNumInsufficientFunds = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "tx_manager_insufficient_funds_tx_count",
 		Help: "Number of transaction broadcast attempts rejected by an RPC node because the sending address had insufficient funds. Increments on every retry while the address remains underfunded, so a sustained rate indicates the address needs topping up.",
-	}, []string{"chainID", "fromAddress"})
+	}, []string{"chainID", "senderAddress"})
 )
 
 type GenericTXMMetrics interface {
@@ -85,7 +85,7 @@ type GenericTXMMetrics interface {
 	IncrementNumConfirmedTxs(ctx context.Context, confirmedTransactions int)
 	RecordTimeUntilTxConfirmed(ctx context.Context, duration float64)
 	RecordBlocksUntilTxConfirmed(ctx context.Context, blocksElapsed float64)
-	IncrementNumInsufficientFundsTxs(ctx context.Context, fromAddress string)
+	IncrementNumInsufficientFundsForTx(ctx context.Context, senderAddress string)
 }
 
 type txmMetrics struct {
@@ -189,10 +189,10 @@ func (m *txmMetrics) RecordBlocksUntilTxConfirmed(ctx context.Context, blocksEla
 	m.blocksUntilTxConfirmed.Record(ctx, blocksElapsed, metric.WithAttributes(attribute.String("chainID", m.chainID)))
 }
 
-func (m *txmMetrics) IncrementNumInsufficientFundsTxs(ctx context.Context, fromAddress string) {
-	promNumInsufficientFunds.WithLabelValues(m.chainID, fromAddress).Add(1)
+func (m *txmMetrics) IncrementNumInsufficientFundsForTx(ctx context.Context, senderAddress string) {
+	promNumInsufficientFunds.WithLabelValues(m.chainID, senderAddress).Add(1)
 	m.numInsufficientFundsTxs.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("chainID", m.chainID),
-		attribute.String("fromAddress", fromAddress),
+		attribute.String("senderAddress", senderAddress),
 	))
 }

--- a/metrics/txm.go
+++ b/metrics/txm.go
@@ -85,7 +85,7 @@ type GenericTXMMetrics interface {
 	IncrementNumConfirmedTxs(ctx context.Context, confirmedTransactions int)
 	RecordTimeUntilTxConfirmed(ctx context.Context, duration float64)
 	RecordBlocksUntilTxConfirmed(ctx context.Context, blocksElapsed float64)
-	IncrementNumInsufficientFundsForTx(ctx context.Context, senderAddress string)
+	IncrementNumInsufficientFundsForTx(ctx context.Context, fromAddress string)
 }
 
 type txmMetrics struct {
@@ -189,10 +189,10 @@ func (m *txmMetrics) RecordBlocksUntilTxConfirmed(ctx context.Context, blocksEla
 	m.blocksUntilTxConfirmed.Record(ctx, blocksElapsed, metric.WithAttributes(attribute.String("chainID", m.chainID)))
 }
 
-func (m *txmMetrics) IncrementNumInsufficientFundsForTx(ctx context.Context, senderAddress string) {
-	promNumInsufficientFunds.WithLabelValues(m.chainID, senderAddress).Add(1)
+func (m *txmMetrics) IncrementNumInsufficientFundsForTx(ctx context.Context, fromAddress string) {
+	promNumInsufficientFunds.WithLabelValues(m.chainID, fromAddress).Add(1)
 	m.numInsufficientFundsTxs.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("chainID", m.chainID),
-		attribute.String("senderAddress", senderAddress),
+		attribute.String("senderAddress", fromAddress),
 	))
 }

--- a/metrics/txm_test.go
+++ b/metrics/txm_test.go
@@ -91,15 +91,15 @@ func TestTxmMetrics_RecordBlocksUntilTxConfirmed(t *testing.T) {
 	)
 }
 
-func TestTxmMetrics_IncrementNumInsufficientFundsTxs(t *testing.T) {
+func TestTxmMetrics_IncrementNumInsufficientFundsForTx(t *testing.T) {
 	m := setupTestTxmMetrics(t)
 
-	m.IncrementNumInsufficientFundsTxs(t.Context(), "0xFromAddress")
-	m.IncrementNumInsufficientFundsTxs(t.Context(), "0xFromAddress")
+	m.IncrementNumInsufficientFundsForTx(t.Context(), "0xSenderAddress")
+	m.IncrementNumInsufficientFundsForTx(t.Context(), "0xSenderAddress")
 
 	require.InEpsilon(t,
 		2.0,
-		testutil.ToFloat64(promNumInsufficientFunds.WithLabelValues("1", "0xFromAddress")),
+		testutil.ToFloat64(promNumInsufficientFunds.WithLabelValues("1", "0xSenderAddress")),
 		0.001,
 	)
 }

--- a/metrics/txm_test.go
+++ b/metrics/txm_test.go
@@ -90,3 +90,16 @@ func TestTxmMetrics_RecordBlocksUntilTxConfirmed(t *testing.T) {
 		testutil.CollectAndCount(promBlocksUntilTxConfirmed),
 	)
 }
+
+func TestTxmMetrics_IncrementNumInsufficientFundsTxs(t *testing.T) {
+	m := setupTestTxmMetrics(t)
+
+	m.IncrementNumInsufficientFundsTxs(t.Context(), "0xFromAddress")
+	m.IncrementNumInsufficientFundsTxs(t.Context(), "0xFromAddress")
+
+	require.InEpsilon(t,
+		2.0,
+		testutil.ToFloat64(promNumInsufficientFunds.WithLabelValues("1", "0xFromAddress")),
+		0.001,
+	)
+}


### PR DESCRIPTION
### Description

Adds a new metric that tracks when we get an error on broadcasting for insufficient funds at the sender address. This metric will surface the case were an executor address needs topping up so we can act to notify the executor to reduce the number of txs that get stuck and the time they are stuck for

[CCIP-11890](https://smartcontract-it.atlassian.net/browse/CCIP-11890)
<!---
  Please include a brief description of changes if not obvious from the PR title

  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
    - PR description
  
  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->

[CCIP-11890]: https://smartcontract-it.atlassian.net/browse/CCIP-11890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ