### PR TITLE
refactor: make oof metric more generic to follow the standard

### DIFF
--- a/metrics/txm.go
+++ b/metrics/txm.go
@@ -71,10 +71,15 @@ var (
 			float64(100),
 		},
 	}, []string{"chainID"})
-	promNumInsufficientFunds = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "tx_manager_insufficient_funds_tx_count",
-		Help: "Number of transaction broadcast attempts rejected by an RPC node because the sending address had insufficient funds. Increments on every retry while the address remains underfunded, so a sustained rate indicates the address needs topping up.",
-	}, []string{"chainID", "senderAddress"})
+	promAttemptError = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "tx_manager_attempt_error_total",
+		Help: "Number of transaction broadcast/confirm attempts that failed, labelled by cause. For cause=\"insufficient_funds\" the sending address was rejected by an RPC node for insufficient funds; it increments on every retry while the address remains underfunded, so a sustained rate indicates the address needs topping up.",
+	}, []string{"chainID", "senderAddress", "cause"})
+)
+
+// Attempt error causes, used as the `cause` label on tx_manager_attempt_error_total.
+const (
+	attemptErrorCauseInsufficientFunds = "insufficient_funds"
 )
 
 type GenericTXMMetrics interface {
@@ -136,9 +141,9 @@ func NewGenericTxmMetrics(chainID string) (GenericTXMMetrics, error) {
 		return nil, fmt.Errorf("failed to register blocks until tx confirmed metric: %w", err)
 	}
 
-	numInsufficientFundsTxs, err := beholder.GetMeter().Int64Counter("tx_manager_insufficient_funds_tx_count")
+	numInsufficientFundsTxs, err := beholder.GetMeter().Int64Counter("tx_manager_attempt_error_total")
 	if err != nil {
-		return nil, fmt.Errorf("failed to register insufficient funds txs metric: %w", err)
+		return nil, fmt.Errorf("failed to register attempt error metric: %w", err)
 	}
 
 	return &txmMetrics{
@@ -190,9 +195,10 @@ func (m *txmMetrics) RecordBlocksUntilTxConfirmed(ctx context.Context, blocksEla
 }
 
 func (m *txmMetrics) IncrementNumInsufficientFundsForTx(ctx context.Context, fromAddress string) {
-	promNumInsufficientFunds.WithLabelValues(m.chainID, fromAddress).Add(1)
+	promAttemptError.WithLabelValues(m.chainID, fromAddress, attemptErrorCauseInsufficientFunds).Add(1)
 	m.numInsufficientFundsTxs.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("chainID", m.chainID),
 		attribute.String("senderAddress", fromAddress),
+		attribute.String("cause", attemptErrorCauseInsufficientFunds),
 	))
 }

--- a/metrics/txm_test.go
+++ b/metrics/txm_test.go
@@ -99,7 +99,7 @@ func TestTxmMetrics_IncrementNumInsufficientFundsForTx(t *testing.T) {
 
 	require.InEpsilon(t,
 		2.0,
-		testutil.ToFloat64(promNumInsufficientFunds.WithLabelValues("1", "0xSenderAddress")),
+		testutil.ToFloat64(promAttemptError.WithLabelValues("1", "0xSenderAddress", "insufficient_funds")),
 		0.001,
 	)
 }


### PR DESCRIPTION
### Description

Update the insufficient funds metric to be more generic by using the cause label pattern that is used for our currently deployed metrics. This also removes fromAddress due to it possible having a high cardinality in the future.
[CCIP-11890](https://smartcontract-it.atlassian.net/browse/CCIP-11890)

<!---
  Please include a brief description of changes if not obvious from the PR title

  Does this work have a corresponding ticket?

  Please link your Jira ticket by including it in one of the following reference:
    - the PR title
    - branch name
    - commit message
    - PR description
  
  Example:

  [LINK-777](https://smartcontract-it.atlassian.net/browse/LINK-777)
--> 

### Requires Dependencies
<!---
  Does this work depend on other open PRs?

  Please list other PRs that are blocking this PR.

  Example:

  - https://github.com/smartcontractkit/chainlink-common/pull/7777777
-->

### Resolves Dependencies
<!---
  Does this work support other open PRs? 

  Please list other PRs that are waiting for this PR to be merged.

  Example:

  - https://github.com/smartcontractkit/ccip/pull/7777777
-->

[CCIP-11890]: https://smartcontract-it.atlassian.net/browse/CCIP-11890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ